### PR TITLE
Ensure only non-JS files are skipped

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,8 +15,8 @@ module.exports = function metalsmithBabel(options) {
   options = Object.assign({}, options);
   let noFilesRenamed = true;
 
-  return function metalsmithBabelPlugin(files, metalsmith) {
-    for (const originalFilename of Object.keys(files)) {
+  return function metalsmithBabelPlugin(files, metalsmith, done) {
+    Object.keys(files).forEach(originalFilename => {
       const ext = extname(originalFilename).toLowerCase();
       if (ext !== '.js' && ext !== '.mjs' && ext !== '.jsx') {
         return;
@@ -51,12 +51,13 @@ module.exports = function metalsmithBabel(options) {
       }
 
       files[filename].contents = SafeBuffer.from(result.code);
-    }
+    });
 
     if (noFilesRenamed) {
-      return;
+      return done();
     }
 
     toFastProperties(files);
+    return done();
   };
 };

--- a/index.js
+++ b/index.js
@@ -15,11 +15,11 @@ module.exports = function metalsmithBabel(options) {
   options = Object.assign({}, options);
   let noFilesRenamed = true;
 
-  return function metalsmithBabelPlugin(files, metalsmith, done) {
-    Object.keys(files).forEach(originalFilename => {
+  return function metalsmithBabelPlugin(files, metalsmith) {
+    for (const originalFilename of Object.keys(files)) {
       const ext = extname(originalFilename).toLowerCase();
       if (ext !== '.js' && ext !== '.mjs' && ext !== '.jsx') {
-        return;
+        continue;
       }
 
       const filename = originalFilename.replace(/\.jsx$/i, '.js');
@@ -51,13 +51,12 @@ module.exports = function metalsmithBabel(options) {
       }
 
       files[filename].contents = SafeBuffer.from(result.code);
-    });
+    }
 
     if (noFilesRenamed) {
-      return done();
+      return;
     }
 
     toFastProperties(files);
-    return done();
   };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-babel",
-  "version": "4.2.2",
+  "version": "4.2.1",
   "description": "Babel plugin for Metalsmith",
   "repository": "babel/metalsmith-babel",
   "author": "Shinnosuke Watanabe (https://github.com/shinnn)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-babel",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Babel plugin for Metalsmith",
   "repository": "babel/metalsmith-babel",
   "author": "Shinnosuke Watanabe (https://github.com/shinnn)",

--- a/test.js
+++ b/test.js
@@ -12,19 +12,19 @@ test('metalsmith-babel', t => {
   new Metalsmith('.')
   .use(babel())
   .run({
-    'source.js': {contents: Buffer.from('(    )    =>    1')},
-    'non-js.txt': {contents: Buffer.from('Hi')}
+    'non-js.txt': {contents: Buffer.from('Hi')},
+    'source.js': {contents: Buffer.from('(    )    =>    1')}
   }, (err, files) => {
     t.equal(err, null, 'should be used as a metalsmith plugin.');
-    t.equal(
-      String(files['source.js'].contents),
-      '() => 1;',
-      'should transform JavaScript files.'
-    );
     t.equal(
       String(files['non-js.txt'].contents),
       'Hi',
       'should not transform non-JavaScript files.'
+    );
+    t.equal(
+      String(files['source.js'].contents),
+      '() => 1;',
+      'should transform JavaScript files.'
     );
   });
 


### PR DESCRIPTION
Hi, I discovered that commit bf3c458 breaks the plugin for 2 reasons:
1. What used to be `forEach(function)` became `for...of`, making the conditional `return` to terminate the entire process rather than skipping a loop iteration.
1. `done` callback was removed for some reason, making the plugin to stall forever.

This shouldn't have passed the test, which it did, from which I can only surmise that the test may be poorly designed.